### PR TITLE
Allow automatic build and serving via github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: docs
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  doc:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+        
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requirements.txt
+      - name: Build documentation
+        run: |
+          mkdocs build -d ./docs_build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs_build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install requirements.txt
+          pip install -r requirements.txt
       - name: Build documentation
         run: |
           mkdocs build -d ./docs_build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs~=1.2
+mkdocs-material~=8.2.1


### PR DESCRIPTION
I found this repo quite useful. It would be nice to have the documents served online so one does not have to do it locally. 
This PR addes the GitHub Action workflow to have the documents built automatically. 
The website should then be avalaible at: https://castep-docs.github.io/castep-docs.

Example hosted website can be seen at: https://zhubonan.github.io/castep-docs

Note that the github pages needs to be enabled and set to "classic", and deploy from "gh-pages" branch in the setting of this repository. 

Example:

![image](https://user-images.githubusercontent.com/33688599/188432128-e926cb01-a1a9-4da3-9fb9-8f72a617df01.png)

It is also possible to get the hosted website at: https://castep-docs.github.io/ (probably makes more sense) with additional configurations (see [here](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites)). 