### PR TITLE
Add castep inputs syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The documentation itself is available at https://castep-docs.github.io/castep-do
 You need python3 set as default then
 ```
  pip install mkdocs-material
+ pip install mkdocs-bibtex
 ```
 And you are ready.  
 ``` 

--- a/docs/documentation/Molecular_Dynamics/basics.md
+++ b/docs/documentation/Molecular_Dynamics/basics.md
@@ -1,28 +1,34 @@
 Fundamental to MD calculations is the calculation time-step. An appropriate value
 for the simulation should be specified in the parameters file in the following way.
 
-```
-md_delta_t  = 2 fs
+```castep_param
+md_delta_t = 2 fs # (1)
 ```
 
-Any valid unit of time can be used when specifying the time-step. The number of
-time-steps to perform is specified with e.g.
+1.  Any valid unit of time can be used when specifying the time-step.
 
-```
+The number of time-steps to perform is specified with e.g.
+
+```castep_param
 md_num_iter = 500
 ```
-NB This is the number of steps to be calculated in this run. It is NOT the accumulated total number of steps in a series of
-continuation runs. The "MD time" value in the `<seed>.castep` file records the cumulative time.
 
-##Ensembles
+!!! note
+
+    This is the number of steps to be calculated in this run. It is NOT the accumulated total
+    number of steps in a series of continuation runs. The "MD time" value in the `<seed>.castep`
+    file records the cumulative time.
+
+## Ensembles
 
 The following statistical ensembles can be simulated using CASTEP.
 
-####NVE
+#### NVE
 
-In this ensemble the number of atoms (N), the shape
-and volume (V) of the simulation cell and the energy (E) remain constant. The conserved energy is the Born-Oppenheimer
-Hamiltonian
+In this ensemble the number of atoms (N), the shape and volume (V) of the simulation cell and the
+energy (E) remain constant.
+
+The conserved energy is the Born-Oppenheimer Hamiltonian
 
 $$E = \left<\Psi|\hat{H}_{e}|\Psi\right> + \frac{1}{2}
 \sum_{i=1}^{N}\sum_{j=1}^{N}\frac{Z_{i}Z_{j}}
@@ -33,7 +39,7 @@ in atomic units.
 
 This ensemble is selected using the command
 
-```
+```castep_param
 md_ensemble  =  NVE
 ```
 
@@ -45,51 +51,56 @@ These ionic velocities are defined in one of three ways.
 
 
 * By explicit user definition of ionic velocities in the cell file, e.g.
-```
-%BLOCK IONIC_VELOCITIES
-auv
-H  xxxxx yyyyy zzzzz
-H  xxxxx yyyyy zzzzz
-O  xxxxx yyyyy zzzzz
-%ENDBLOCK IONIC_VELOCITIES
-```
-using any valid unit of velocity (auv is atomic unit of velocity), etc.
+
+    ```castep_cell
+    %BLOCK IONIC_VELOCITIES
+    auv # (1)!
+    H  xxxxx yyyyy zzzzz
+    H  xxxxx yyyyy zzzzz
+    O  xxxxx yyyyy zzzzz
+    %ENDBLOCK IONIC_VELOCITIES
+    ```
+
+    1. using any valid unit of velocity (auv is atomic unit of velocity), etc.
 
 * By definition of an initial temperature in the parameters file, e.g.
-```
-md_temperature  =  293 K
-```
-Note that this can be specified using any valid unit
-of temperature. In this case initial velocities are assigned randomly
-such that the total linear momentum is zero and the instantaneous
-temperature matches that specified. The system will reach
-equilibrium with a somewhat different temperature due to equipartition of kinetic and potential energy.
 
+    ```castep_param
+    md_temperature = 293 K # (1)
+    ```
+
+    1. Note that this can be specified using any valid unit of temperature.
+
+    In this case initial velocities are assigned randomly such that the total linear momentum is zero
+    and the instantaneous temperature matches that specified. The system will reach equilibrium with a
+    somewhat different temperature due to equipartition of kinetic and potential energy.
 
 * By continuation from an equilibrated run at the desired temperature. This
 could be a run in any of the other available ensembles. This will also use the
 cell and ionic positions from the continuation file. See the section on
 continuation for details.
 
-Velocities read from a continuation file will always take precedence. If no
-continuation file is used, and both `md_temperature` and an `IONIC_VELOCITIES`
-block are specified, the `md_temperature` keyword will be ignored.
+!!! note
+
+    Velocities read from a continuation file will always take precedence. If no
+    continuation file is used, and both `md_temperature` and an `IONIC_VELOCITIES`
+    block are specified, the `md_temperature` keyword will be ignored.
 
 By default, pressure is not calculated during an NVE run. To override this
 use the command
 
-```
+```castep_param
 calculate_stress = true
 ```
 
 in the parameters file.
 
-####NVT
+#### NVT
 
 This ensemble is selected with
 
-```
-md_ensemble  =  NVT
+```castep_param
+md_ensemble = NVT
 ```
 
 The system will be evolved to a specific temperature defined using
@@ -102,16 +113,18 @@ Temperature control can be implemented by one of several methods, all
 of which have been shown to correctly sample the canonical ensemble. The
 first of these is the deterministic Nose-Hoover chain method of Tuckerman et al [@Martyna1992]  and is selected with
 
-```
-md_thermostat  =  nose-hoover
+```castep_param
+md_thermostat = nose-hoover
 ```
 
-in the parameters file. In the NVT case, a single Nose-Hoover chain
-is coupled to all particle degrees of freedom. The length of the
-chain can also be specified, e.g.
+in the parameters file.
 
-```
-md_nhc_length  =  5
+
+In the NVT case, a single Nose-Hoover chain is coupled to all particle degrees of freedom. The
+length of the chain can also be specified, e.g.
+
+```castep_param
+md_nhc_length = 5
 ```
 
 for a chain of five thermostats.
@@ -128,15 +141,14 @@ is the pseudo-Hamiltonian
 + N_{f}k_{B}T\xi_{1} + k_{B}T\sum_{i=2}^{M}\xi_{i}
 \end{equation}
 
-where the $Q_{i}$ are the thermostat fictitious masses assigned automatically
-from the specified ion relaxation time and $\xi_{i}$ are the thermostat degrees of
-freedom. This is printed with the label
-``Hamilt    Energy:``  at each time-step. A Nose-Hoover thermostat with no chain (i.e. with $M$=1 ) is known to not be
-ergodic and hence should be avoided.
+where the $Q_{i}$ are the thermostat fictitious masses assigned automatically from the specified ion
+relaxation time and $\xi_{i}$ are the thermostat degrees of freedom. This is printed with the label
+`Hamilt Energy:` at each time-step. A Nose-Hoover thermostat with no chain (i.e. with $M$=1 ) is
+known to not be ergodic and hence should be avoided.
 
 The second method of controlling temperature is through the stochastic Langevin thermostat.
 
-```
+```castep_param
 md_thermostat = langevin
 ```
 
@@ -146,34 +158,39 @@ exhibit no long term drift from the equilibrium value.
 
 Finally, the temperature may be controled via the Hoover-Langevin thermostat.
 
-```
+```castep_param
 md_thermostat = hoover-langevin
 ```
-which is the fusion of a deterministic Nose-Hoover thermostat acting directly on the physical system, with a Langevin
-thermostat operating on the Nose-Hoover variables, in order to guarantee ergodicity.
 
-With each method, a suitable relaxation time for the thermostatic
-process should be specified. This can use any supported unit of
-time, e.g
+which is the fusion of a deterministic Nose-Hoover thermostat acting directly on the physical
+system, with a Langevin thermostat operating on the Nose-Hoover variables, in order to guarantee
+ergodicity.
 
+With each method, a suitable relaxation time for the thermostatic process should be specified, e.g
+
+```castep_param
+md_ion_t = 2.4 ps # (1)!
 ```
-md_ion_t = 2.4 ps
-```
 
-for a thermostat relaxation time of 2.4 picoseconds. The Hoover-Langevin thermostat is the LEAST sensitive to the choice of
-this value.
+1. This can use any supported unit of time
 
-As with the NVE ensemble, pressure is not calculated by default. This is
-overridden in the same way as the NVE case.
+for a thermostat relaxation time of 2.4 picoseconds.
 
-####NPH
+!!! note
 
-In this ensemble the size and (if desired) shape of the simulation
-cell varies to regulate pressure. No thermostat is applied and hence the enthalpy (H) is conserved.
+    The Hoover-Langevin thermostat is the LEAST sensitive of the thermostats to the choice of this value.
+
+As with the NVE ensemble, pressure is not calculated by default. This is overridden in the same way
+as the NVE case.
+
+#### NPH
+
+In this ensemble the size and (if desired) shape of the simulation cell varies to regulate
+pressure. No thermostat is applied and hence the enthalpy (H) is conserved.
 
 This ensemble is specified with the following:
 
-```
+```castep_param
 md_ensemble = NPH
 ```
 
@@ -182,13 +199,13 @@ any valid unit of pressure. The required symmetry of the external pressure
 tensor implies that only the upper triangular components need be
 specified, e.g.
 
-```
-     %block external_pressure
-     GPa
-     0.5   0.0  0.0
-           0.5  0.0
-                0.5
-     %endblock external_pressure
+```castep_cell
+%block external_pressure
+GPa
+0.5   0.0  0.0
+      0.5  0.0
+           0.5
+%endblock external_pressure
 ```
 
 to specify an isotropic external pressure of 0.5 Giga-Pascals. MD can also support non-isotropic pressure if using a
@@ -203,7 +220,7 @@ of the cell to isotropic expansions and contractions. This
 follows the method of Andersen[@Andersen1980] and Hoover[@Hoover1985;@Hoover1986] as corrected
 by Martyna et al.[@Martyna1994]. This is selected using:
 
-```
+```castep_param
 md_barostat = andersen-hoover
 ```
 
@@ -228,7 +245,7 @@ of Martyna, Tobias and Klien[@Martyna1994].
 The following line in the parameters file selects this barostat.
 
 
-```
+```castep_param
 md_barostat = parrinello-rahman
 ```
 
@@ -243,12 +260,13 @@ H = \left<\Psi|\hat{H}_{e}|\Psi\right> + \frac{1}{2}
 +\sum_{i=1}^{N}\frac{P_{i}^{2}}{2M_{i}} + P_{ext}V + \mathrm{Tr}[{\mathbf{p}_{g}\mathbf{p}_{g}^{T}]}/2W
 \end{equation}
 
-For both barostats, a relaxation time for the cell motions should be specified
-with an appropriate unit of time, for example:
+For both barostats, a relaxation time for the cell motions should be specified, e.g.:
 
+```castep_param
+md_cell_t = 20 ps # (1)!
 ```
-md_cell_t = 20 ps
-```
+
+1. This can use any supported unit of time
 
 This time is used to calculate a fictitious mass $W$ for the cell dynamics and should be large compared to the
 characteristic time for the ionic dynamics.
@@ -265,7 +283,7 @@ changes.
 The user therefore has two options. The first is to fix the size
 of the basis set.
 
-```
+```castep_param
 fixed_npw = true
 ```
 
@@ -276,9 +294,10 @@ with respect to the number of plane waves.
 
 The second option is to allow the basis set to change at each time-step.
 
-```
+```castep_param
 fixed_npw = false
 ```
+
 which is the default value. This keeps the cut-off energy approximately constant by adding
 or subtracting plane waves from the basis set at each time-step.
 
@@ -290,11 +309,11 @@ of plane waves the energy correction is no longer constant
 and is recalculated at each step.
 
 
-####NPT
+#### NPT
 
 The NPT ensemble is specified with the command:
 
-```
+```castep_param
 md_ensemble = NPT
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs~=1.2
 mkdocs-material~=8.2.1
 mkdocs-bibtex~=2.14.1
+castep_pygments @ git+https://github.com/oerc0122/castep_pygments.git


### PR DESCRIPTION
- Adds syntax highlighting to castep input files through [`castep_pygments`](https://github.com/oerc0122/castep_pygments) package
- Adds ability to add code annotations into castep input blocks
- Demonstrated in MD/Basics