### PR TITLE
Corrected a few typos and added warning for XC_DEFINITION usage

### DIFF
--- a/docs/documentation/Groundstate/population_analysis.md
+++ b/docs/documentation/Groundstate/population_analysis.md
@@ -60,7 +60,7 @@ is calculated, where $Z'$ is the pseudoatom nuclear charge.
 ### The CASTEP implementation
 
 In CASTEP, the solution of the electronic problem results in a set of Kohn-Sham orbitals $\psi _ i$, which are expressed in terms of plane-wave functions. Plane-waves are non-local, therefore not
-directly suitable for Mulliken population analysis. In order to obtain a suitable local basis, CASTEP solves the electronic problem of the isolated atom for each atomic specie present in the system,
+directly suitable for Mulliken population analysis. In order to obtain a suitable local basis, CASTEP solves the electronic problem of the isolated atom for each atomic species present in the system,
 resulting in a set of atomic orbitals $\chi _ \mu$. Note that for this set of calculations, the same calculation settings (e.g. electronic cutoff and pseudopotentials) are used. With the atomic
 orbitals determined, the Mulliken population analysis can be performed by calculating the projections $\langle \chi _ \mu | \psi _ i \rangle$.
 

--- a/docs/documentation/XC/XC.md
+++ b/docs/documentation/XC/XC.md
@@ -71,6 +71,12 @@ LDA-C 1.0
 %endblock xc_definition
 ```
 
+!!! warning
+	When specifying parameters within the `xc_definition` block, one should not
+	specify separator characters such `:` or `=` between the keyword and parameters.
+	In addition, note that functional names within XC definition are **case-sensitive**
+	and should thus be entered in uppercase.
+
 Examples:  
 1. B3LYP
 Firstly you can simply use `xc_functional : B3LYP`, however

--- a/docs/documentation/XC/XC.md
+++ b/docs/documentation/XC/XC.md
@@ -73,7 +73,7 @@ LDA-C 1.0
 
 Examples:  
 1. B3LYP
-Firstly you cansimply use `xc_functional : B3LYP`, however
+Firstly you can simply use `xc_functional : B3LYP`, however
 `B3LYP` is a hybrid functional consisting of a mixture of
 Hartree-Fock, LDA and B88 exchange, LYP and LDA correlation. This
 functional can be specified component by component:


### PR DESCRIPTION
I spotted a few minor spelling mistakes in the XC and population analysis of the documentation. 

Also, following an email exchange a while back, updated the relevant section regarding the use of XC_DEFINITION to state that it is not case-sensitive and the usual separation characters (':', '=' for instance) may not be used in the block. I don't know if we want to include this bit in the docs as one coudl make a case that the code should be be updated to make this unnecessary. 
